### PR TITLE
Fix a typo in namespace change.

### DIFF
--- a/docs/why.md
+++ b/docs/why.md
@@ -40,7 +40,7 @@ For symmetric keys, the constructor's parameter has changed from being a constan
 
 SSH2, SFTP and X.509 are largely unchanged.
 
-The name space has also been changed from `\phpseclib` to `\phpsecib3`.
+The name space has also been changed from `\phpseclib` to `\phpseclib3`.
 
 phpseclib 1.0 / 2.0 documentation lives at http://phpseclib.sourceforge.net/
 


### PR DESCRIPTION
Found a typo, fixed it :)

(github's editor might have added a line break at the end too, sorry!)