### PR TITLE
Docs: correct SFTP get() return value

### DIFF
--- a/versioned_docs/version-4.0/ssh2/sftp.md
+++ b/versioned_docs/version-4.0/ssh2/sftp.md
@@ -104,7 +104,7 @@ echo $sftp->get('filename.remote');
 $sftp->get('filename.remote', 'filename.local');
 ```
 
-Returns a string containing the contents of `$remote_file` if `$local_file` is left undefined or a boolean false if the operation was unsuccessful. If `$local_file` is defined, returns true or false depending on the success of the operation.
+Returns a string containing the contents of `$remote_file` if `$local_file` is left undefined. If `$local_file` is defined, the download is written to the provided file path, stream resource, or callback, and the method returns `null`.
 
 If `$local_file` is an anonymous function you can stream the download real time or whatever. eg.
 


### PR DESCRIPTION
## Summary

Correct the `get()` documentation in the SFTP docs.

The current docs say that `get()` returns `true` on success when `$local_file` is provided. That is not accurate for the current implementation. The method returns:

- `string` when `$local_file` is omitted
- `null` when the download is written to a local file, stream, or callback